### PR TITLE
Performance improvements, separate commands for inverse filter, in place filter

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,4 +1,4 @@
 [  
-    { "keys": ["ctrl+k", "ctrl+r"], "command": "prompt_filter_to_lines", "args": { "search_type": "regex" } },
-    { "keys": ["ctrl+k", "ctrl+s"], "command": "prompt_filter_to_lines", "args": { "search_type": "string" } }
+    { "keys": ["ctrl+k", "ctrl+r"], "command": "prompt_filter_to_lines", "args": { "search_type": "regex", "invert_search": false } },
+    { "keys": ["ctrl+k", "ctrl+s"], "command": "prompt_filter_to_lines", "args": { "search_type": "string", "invert_search": false } }
 ] 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,4 @@
 [  
-    { "keys": ["super+k", "super+r"], "command": "prompt_filter_to_lines", "args": { "search_type": "regex" } },
-    { "keys": ["super+k", "super+s"], "command": "prompt_filter_to_lines", "args": { "search_type": "string" } }
+    { "keys": ["super+k", "super+r"], "command": "prompt_filter_to_lines", "args": { "search_type": "regex", "invert_search": false } },
+    { "keys": ["super+k", "super+s"], "command": "prompt_filter_to_lines", "args": { "search_type": "string", "invert_search": false } }
 ] 

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,4 +1,4 @@
 [  
-    { "keys": ["ctrl+k", "ctrl+r"], "command": "prompt_filter_to_lines", "args": { "search_type": "regex" } },
-    { "keys": ["ctrl+k", "ctrl+s"], "command": "prompt_filter_to_lines", "args": { "search_type": "string" } }
+    { "keys": ["ctrl+k", "ctrl+r"], "command": "prompt_filter_to_lines", "args": { "search_type": "regex", "invert_search": false } },
+    { "keys": ["ctrl+k", "ctrl+s"], "command": "prompt_filter_to_lines", "args": { "search_type": "string", "invert_search": false } }
 ] 

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,6 +1,10 @@
 [
-    { "caption": "Filter Lines: Filter With Regex", "command": "prompt_filter_to_lines", "args": { "search_type": "regex" } },
-    { "caption": "Filter Lines: Filter With String", "command": "prompt_filter_to_lines", "args": { "search_type": "string" } },
-    { "caption": "Filter Lines: Fold With Regex", "command": "prompt_fold_to_lines", "args": { "search_type": "regex" } },
-    { "caption": "Filter Lines: Fold With String", "command": "prompt_fold_to_lines", "args": { "search_type": "string" } }
+    { "caption": "Filter Lines: Include lines with Regex", "command": "prompt_filter_to_lines", "args": { "search_type": "regex", "invert_search": false } },
+    { "caption": "Filter Lines: Include lines with String", "command": "prompt_filter_to_lines", "args": { "search_type": "string", "invert_search": false } },
+    { "caption": "Filter Lines: Exclude lines with Regex", "command": "prompt_filter_to_lines", "args": { "search_type": "regex", "invert_search": true } },
+    { "caption": "Filter Lines: Exclude lines with String", "command": "prompt_filter_to_lines", "args": { "search_type": "string", "invert_search": true } },
+    { "caption": "Filter Lines: Fold Excluding Regex", "command": "prompt_fold_to_lines", "args": { "search_type": "regex", "invert_search": false } },
+    { "caption": "Filter Lines: Fold Excluding String", "command": "prompt_fold_to_lines", "args": { "search_type": "string", "invert_search": false } },
+    { "caption": "Filter Lines: Fold With Regex", "command": "prompt_fold_to_lines", "args": { "search_type": "regex", "invert_search": true } },
+    { "caption": "Filter Lines: Fold With String", "command": "prompt_fold_to_lines", "args": { "search_type": "string", "invert_search": true } }
 ]

--- a/Filter Lines.sublime-settings
+++ b/Filter Lines.sublime-settings
@@ -10,10 +10,6 @@
 	// string or regex will be blank
 	"preserve_search": true,
 
-	// If true, find lines that do not match (useful when
-	// progressively eliminating noise in log files)
-	"invert_search": false,
-
 	// Show source file line numbers in results
 	"line_numbers": false,
 

--- a/Filter Lines.sublime-settings
+++ b/Filter Lines.sublime-settings
@@ -15,5 +15,8 @@
 	"invert_search": false,
 
 	// Show source file line numbers in results
-	"line_numbers": false
+	"line_numbers": false,
+
+	// Create new tab for filter results
+	"create_new_tab": true
 }

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -8,8 +8,10 @@
                 "children":
                 [
                     { "caption": "-" },
-                    { "caption": "Filter With Regex", "command": "prompt_filter_to_lines", "args": { "search_type": "regex" } },
-                    { "caption": "Filter With String", "command": "prompt_filter_to_lines", "args": { "search_type": "string" } }
+                    { "caption": "Include lines with Regex", "command": "prompt_filter_to_lines", "args": { "search_type": "regex", "invert_search": false } },
+                    { "caption": "Include lines with String", "command": "prompt_filter_to_lines", "args": { "search_type": "string", "invert_search": false } },
+                    { "caption": "Exclude lines with Regex", "command": "prompt_filter_to_lines", "args": { "search_type": "regex", "invert_search": true } },
+                    { "caption": "Exclude lines with String", "command": "prompt_filter_to_lines", "args": { "search_type": "string", "invert_search": true } }
                 ]
             },
             {
@@ -17,8 +19,10 @@
                 "children":
                 [
                     { "caption": "-" },
-                    { "caption": "Fold With Regex", "command": "prompt_fold_to_lines", "args": { "search_type": "regex" } },
-                    { "caption": "Fold With String", "command": "prompt_fold_to_lines", "args": { "search_type": "string" } }
+                    { "caption": "Fold Excluding Regex", "command": "prompt_fold_to_lines", "args": { "search_type": "regex", "invert_search": false } },
+                    { "caption": "Fold Excluding String", "command": "prompt_fold_to_lines", "args": { "search_type": "string", "invert_search": false } },
+                    { "caption": "Fold With Regex", "command": "prompt_fold_to_lines", "args": { "search_type": "regex", "invert_search": true } },
+                    { "caption": "Fold With String", "command": "prompt_fold_to_lines", "args": { "search_type": "string", "invert_search": true } }
                 ]
             }
         ]

--- a/filter.py
+++ b/filter.py
@@ -53,6 +53,7 @@ class FilterToLinesCommand(sublime_plugin.TextCommand):
         self.invert_search = settings.get('invert_search', False)
         flags = self.get_search_flags(search_type, settings)
         lines = itertools.groupby(self.view.find_all(needle, flags), self.view.line)
+        lines = [l for l, _ in lines]
         self.line_numbers = settings.get('line_numbers', False)
         self.show_filtered_lines(edit, lines)
 
@@ -74,13 +75,10 @@ class FilterToLinesCommand(sublime_plugin.TextCommand):
         results_view.settings().set('word_wrap', self.view.settings().get('word_wrap'))
 
         if self.invert_search:
-            source_lines = self.view.lines(sublime.Region(0, self.view.size()))
-            filtered_line_numbers = [self.view.rowcol(line.begin())[0] for line, _ in lines]
+            filtered_line_numbers = [self.view.rowcol(line.begin())[0] for line in lines]
+            lines = self.view.lines(sublime.Region(0, self.view.size()))
             for line_number in reversed(filtered_line_numbers):
-                del source_lines[line_number]
-            lines = source_lines
-        else:
-            lines = [l for l, _ in lines]
+                del lines[line_number]
 
         text = '\n'.join([self.prepare_output_line(l) for l in lines]);
         results_view.run_command('append', {'characters': text, 'force': True, 'scroll_to_end': False})

--- a/filter.py
+++ b/filter.py
@@ -31,7 +31,7 @@ class PromptFilterToLinesCommand(sublime_plugin.WindowCommand):
         self.search_text = search_text
         self.save_settings()
         if self.window.active_view():
-            self.window.active_view().run_command(self.filter_command, { 
+            self.window.active_view().run_command(self.filter_command, {
                 "needle": self.search_text, "search_type": self.search_type })
 
     def load_settings(self):
@@ -78,21 +78,17 @@ class FilterToLinesCommand(sublime_plugin.TextCommand):
             filtered_line_numbers = [self.view.rowcol(line.begin())[0] for line, _ in lines]
             for line_number in reversed(filtered_line_numbers):
                 del source_lines[line_number]
-            text = ''
-            for line in source_lines:
-                text += self.prepare_output_line(line, None)
-            results_view.run_command('append', {'characters': text, 'force': True, 'scroll_to_end': False})
+            lines = source_lines
         else:
-            text = ''
-            for line, matches in lines:
-                text += self.prepare_output_line(line, matches)
-            results_view.run_command('append', {'characters': text, 'force': True, 'scroll_to_end': False})
+            lines = [l for l, _ in lines]
 
+        text = '\n'.join([self.prepare_output_line(l) for l in lines]);
+        results_view.run_command('append', {'characters': text, 'force': True, 'scroll_to_end': False})
         results_view.set_syntax_file(self.view.settings().get('syntax'))
 
-    def prepare_output_line(self, line, matches):
+    def prepare_output_line(self, line):
         if self.line_numbers and not self.invert_search:
             line_number = self.view.rowcol(line.begin())[0]
-            return '%5d: %s\n' % (line_number, self.view.substr(line))
+            return '%5d: %s' % (line_number, self.view.substr(line))
         else:
-            return '%s\n' % (self.view.substr(line))
+            return self.view.substr(line)

--- a/filter.py
+++ b/filter.py
@@ -63,7 +63,7 @@ class FilterToLinesCommand(sublime_plugin.TextCommand):
             if not settings.get('case_sensitive_string_search', False):
                 flags = flags | sublime.IGNORECASE
         elif search_type == 'regex':
-            if not settings.get('case_sensitive_string_search', False):
+            if not settings.get('case_sensitive_regex_search', False):
                 flags = sublime.IGNORECASE
         return flags
 

--- a/fold.py
+++ b/fold.py
@@ -7,8 +7,8 @@ from .filter import FilterToLinesCommand
 
 class PromptFoldToLinesCommand(PromptFilterToLinesCommand):
 
-    def run(self, search_type = 'string'):
-        self._run(search_type, "fold_to_lines", "Fold")
+    def run(self, search_type = 'string', invert_search = False):
+        self._run(search_type, "fold_to_lines", "Fold", invert_search)
 
 
 class FoldToLinesCommand(FilterToLinesCommand):

--- a/fold.py
+++ b/fold.py
@@ -33,6 +33,3 @@ class FoldToLinesCommand(FilterToLinesCommand):
             regions.append(region)
         if regions:
             self.view.fold(regions)
-
-    def prepare_output_line(self, line, matches):
-        pass

--- a/fold.py
+++ b/fold.py
@@ -15,7 +15,7 @@ class FoldToLinesCommand(FilterToLinesCommand):
 
     def show_filtered_lines(self, edit, lines):
         source_lines = self.view.lines(sublime.Region(0, self.view.size()))
-        filtered_line_numbers = [self.view.rowcol(line.begin())[0] for line, _ in lines]
+        filtered_line_numbers = {self.view.rowcol(line.begin())[0] for line, _ in lines}
         regions = []
         region = None
         for line in source_lines:

--- a/fold.py
+++ b/fold.py
@@ -15,7 +15,7 @@ class FoldToLinesCommand(FilterToLinesCommand):
 
     def show_filtered_lines(self, edit, lines):
         source_lines = self.view.lines(sublime.Region(0, self.view.size()))
-        filtered_line_numbers = {self.view.rowcol(line.begin())[0] for line, _ in lines}
+        filtered_line_numbers = {self.view.rowcol(line.begin())[0] for line in lines}
         regions = []
         region = None
         for line in source_lines:


### PR DESCRIPTION
This PR contains major performance improvements and 2 new functions:

* invert_search is promoted to a command parameter and separate commands are created for include and exclude filters
* an option for in place replacement

I saw that you previously removed in place filtering. I don't know your reasons but feel free to include only performance commits from this PR. I've made sure that each commit is separate and doesn't introduce complexity, in place editing is added with only few lines of code.