### PR TITLE
Fixing ReadMe: Include lines with Regex shortcut.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Quickly find all lines matching a string or regular expression in Sublime Text.
 
 On the Edit > Line menu:
 
-* Include lines with Regex  <kbd>⌘+K</kbd> <kbd>⌘+S</kbd>
+* Include lines with Regex  <kbd>⌘+K</kbd> <kbd>⌘+R</kbd>
 * Include lines with String  <kbd>⌘+K</kbd> <kbd>⌘+S</kbd>
 * Exclude lines with Regex
 * Exclude lines with String


### PR DESCRIPTION
The keyboard shortcut was specified as Cmd-S when it should be Cmd-R (as you provided in the Package Control Notes). 