### PR TITLE
Exclude filter_lines_demo.gif while packaging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+filter_lines_demo.gif export-ignore


### PR DESCRIPTION
The `filter_lines_demo.gif` makes `Filter Lines.sublime-package` unnecessarily bloated ~1.54MB. By removing it from the package, `Filter Lines.sublime-package` is ~12KB.